### PR TITLE
feat(commit-prompter): Introduce Style Option for Commit Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ possible options, run `gc-smart --help`.
     cd SmartCommit
     ```
 
-    Alternatively just copy the files `gc-smart` and `ai_commit_helper.py` to
+    Alternatively just copy the files `gc-smart` and `gpt-commit-prompter` to
     the preferred location.
     
 2. Install the necessary Python libraries:
@@ -95,11 +95,11 @@ possible options, run `gc-smart --help`.
 
     Alternatively, you can create an alias for `gc-smart` providing the full path.
 
-6. Make the `gc-smart` and `ai_commit_helper.py` script executable:
+6. Make the `gc-smart` and `gpt-commit-prompter` script executable:
 
     ```bash
         chmod +x /path/to/gc-smart
-        chmod +x /path/to/ai_commit_helper.py
+        chmod +x /path/to/gpt-commit-prompter.py
     ```
     (Don't forget to replace `/path/to/gc-smart` with the actual path to the script.
 
@@ -161,17 +161,23 @@ changes to your repository.
 
 ## Commit Message Style
 
-The `ai_commit_helper.py` script uses a specific style for the commit messages it
-generates. The messages include a summary title, followed by a detailed list of
-changes. Each change is denoted by a bullet point - and written in an
-imperative style. See the example above.
+The `gpt-commit-prompter` script uses the `imperative` style as its default for
+the commit messages it generates. However, you have the flexibility to
+configure the style through the `-s` or `--style` option.
 
-The configuration for this style is hard-coded in the script. If
-you wish to change the style, feel free to modify the system_prompt and
-changes variables in the script.
+Available styles are:
 
-As of now, there is no option to select different styles of commit messages
-directly. However, this may be a feature in future versions.
+- `imperative`: Generates a message in the imperative mood and uses title with
+  bullets.
+- `simple`: Generates a concise, straightforward commit message in one line.
+- `detailed`: Generates a more verbose commit message, detailing the changes.
+- `conventional`: Generates a commit message following the conventional commits
+  specification.
+
+These styles can also be used in combination with the `gc-smart` script.
+
+You can see how the styles are configured and further customize them by
+checking the `config.json` file.
 
 ## License
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,17 @@
+{
+    "style": {
+        "imperative": {
+            "system_prompt": "You are a helpful assistant that generates meaningful commit messages based on a diff file. The commit message should include a title summarizing the changes and bullets '-' for the detailed changes. Each change should be on a new line in an imperative style. Please ensure that no line exceeds 80 characters in length."
+        },
+        "simple": {
+            "system_prompt": "You are a helpful assistant that generates meaningful commit messages based on a diff file. Provide a concise and clear commit message summarizing the changes in one line."
+        },
+        "detailed": {
+            "system_prompt": "You are a helpful assistant that generates meaningful commit messages based on a diff file. Generate a detailed and thorough commit message breaking down the changes with bullet points and explanations."
+        },
+        "conventional": {
+            "system_prompt": "You are a helpful assistant that generates meaningful commit messages based on a diff file. Generate a commit message following the Conventional Commits format. The commit should start with a type, optionally a scope, and a description. If necessary, provide additional context or reasons for the changes."
+        }
+    }
+}
+

--- a/gc-smart
+++ b/gc-smart
@@ -6,7 +6,7 @@
 #
 # Filename  : gc-smart
 # Author(s) : David Schmid (david.schmid@mailbox.org)
-# Version   : 0.2.0
+# Version   : 0.3.0
 #
 # ------------------------------ Description -----------------------------------
 # Leverages gpt-commit-prompter to auto-generate commit messages for staged
@@ -37,6 +37,7 @@ GIT_ROOT="" # The root directory of the current Git repository
 INSTRUCTION="" # Additional instructions for enhancing the AI commit message
 KEEP_FILES=false # Flag to retain intermediate files after the commit process
 PREVIEW=true # Flag to preview the AI-generated commit message to the user
+STYLE="" # Style for the AI-generated commit message
 
 
 # ------------------------------------------------------------------------------
@@ -55,9 +56,10 @@ print_help() {
     echo "Options:"
     echo "-h, --help          Display this help message."
     echo "-i, --instruction   Provide an instruction for the AI to guide commit message generation."
-    echo "--keep-files        Retain intermediate files after the commit process in the root directory."
     echo "-q, --quick         Skip the preview of the AI generated commit message and commit directly."
-	echo "--cmd               Specify a custom command for Git operations. Default is 'git'."
+    echo "-s, --style         Specify a style for the AI-generated commit message: imperative, detailed, simple, conventional."
+    echo "--keep-files        Retain intermediate files after the commit process in the root directory."
+    echo "--cmd               Specify a custom command for Git operations. Default is 'git'."
 
 }
 
@@ -232,6 +234,25 @@ set_git_cmd() {
     done
 }
 
+set_style_option() {
+    # Parse the command line arguments to detect a possible "-s" or "--style"
+    # flag. If detected, set the STYLE variable to the value provided after
+    # the flag.
+    local args=("$@")
+    for idx in "${!args[@]}"; do
+        if [ "${args[$idx]}" == "-s" ] || [ "${args[$idx]}" == "--style" ]; then
+            # Check if a potential style follows the flag
+            if [ -n "${args[$idx+1]-}" ] && [[ "${args[$idx+1]}" != -* ]]; then
+                STYLE="${args[$idx+1]}"
+                break
+            else
+                echo "Error: The -s or --style option requires an argument."
+                exit 1
+            fi
+        fi
+    done
+}
+
 
 # Commit Message Generation and Handling
 # ------------------------------------------------------------------------------
@@ -242,7 +263,9 @@ generate_commit_message() {
     # Write the message to tmp_commit_msg.txt.
     # NOTE: The gpt-commit-prompter script must be located in the same directory
     # as this executing script for this function to work correctly.
-    if [ -n "$INSTRUCTION" ]; then
+    if [ -n "$STYLE" ]; then
+        python3 "$DIR/gpt-commit-prompter" "$GIT_ROOT/staged_changes.diff" -i "$INSTRUCTION" -s "$STYLE" > "$GIT_ROOT/tmp_commit_msg.txt"
+    elif [ -n "$INSTRUCTION" ]; then
         python3 "$DIR/gpt-commit-prompter" "$GIT_ROOT/staged_changes.diff" -i "$INSTRUCTION" > "$GIT_ROOT/tmp_commit_msg.txt"
     else
         python3 "$DIR/gpt-commit-prompter" "$GIT_ROOT/staged_changes.diff" > "$GIT_ROOT/tmp_commit_msg.txt"
@@ -322,6 +345,7 @@ set_keep_files_flag "$@"
 set_preview_flag "$@"
 set_instruction "$@"
 set_git_cmd "$@"
+set_style_option "$@"
 set_directories
 
 if [[ "$GIT_CMD" == "git" ]]; then

--- a/gpt-commit-prompter
+++ b/gpt-commit-prompter
@@ -6,7 +6,7 @@
 ================================================================================
 
 Author(s) : David Schmid (david.schmid@mailbox.org)
-Version   : 0.1.0
+Version   : 0.2.0
 
 ------------------------------ Description -----------------------------------
 Utilizes OpenAI's GPT-3 model to auto-generate git commit messages from
@@ -27,9 +27,16 @@ Execute the script with changes in string format or by indicating a .diff file:
 ================================================================================
 """
 
-import openai
 import argparse
+import json
 import os
+import openai
+
+
+def load_config(file_path="config.json"):
+    with open(file_path, "r") as f:
+        return json.load(f)
+
 
 def set_openai_key():
     if "OPENAI_API_KEY" not in os.environ:
@@ -50,9 +57,18 @@ def get_args():
     )
 
     parser.add_argument(
-        "-i", "--instruction",
+        "-i",
+        "--instruction",
         default="",
-        help="Additional instruction to guide the AI's response"
+        help="Additional instruction to guide the AI's response",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--style",
+        default="imperative",
+        choices=["imperative", "simple", "detailed", "conventional"],
+        help="Commit message style",
     )
 
     return parser.parse_args()
@@ -69,16 +85,16 @@ def get_changes(args):
         return args.changes
 
 
-def generate_commit_message(changes, instruction):
-    system_prompt = (
-        "You are a helpful assistant that generates meaningful commit messages based "
-        "on a list of changes. The commit message should include a title summarizing "
-        "the changes and bullets '-' for the detailed changes. Each change should be "
-        "on a new line in an imperative style. Please ensure that no line "
-        "exceeds 80 characters in length."
-    )
+def generate_commit_message(changes, instruction, style="imperative"):
+    config = load_config()
 
-    changes = "Write a git commit message for the following changes: " + changes
+    # Ensure the provided style is in the configuration
+    if style not in config["style"]:
+        raise ValueError(f"Style '{style}' not found in configuration.")
+
+    system_prompt = config["style"][style]["system_prompt"]
+
+    changes = "Write a git commit message for the following changes: \n\n" + changes
 
     # Add the instruction to the AI messages
     messages = [
@@ -105,7 +121,7 @@ def main():
 
     changes = get_changes(args)
 
-    commit_message = generate_commit_message(changes, args.instruction)
+    commit_message = generate_commit_message(changes, args.instruction, args.style)
 
     print(commit_message)
 


### PR DESCRIPTION
The `gc-smart` script now supports a new `--style` option to specify the style for the AI-generated commit message.
The available styles are: `imperative`, `simple`, `detailed`, and `conventional`. The default style is `imperative`.

The new configuration file `config.json` allows further customization of the commit message styles. Each style has a corresponding system prompt to guide the AI in generating the commit message.

Changes made:

- Change `ai_commit_helper.py` to `gpt-commit-prompter`
- Update file names in README.md to reflect new script names
- Update version number in `gc-smart` script from 0.2.0 to 0.3.0
- Add a new flag `-s` or `--style` to specify the style of the AI-generated commit message
- Implement four styles: imperative, simple, detailed, and conventional
- Create a `config.json` file to store the different styles and their system prompts
- Implement function to load the configuration from `config.json`
- Modify `generate_commit_message` function to accept a `style` parameter
- Validate that the provided style exists in the configuration
- Use the system prompt for the selected style in `generate_commit_message`
- Update the help message and usage information for the `gc-smart` script